### PR TITLE
Treat all TOC entries equally and indent sub-headings

### DIFF
--- a/assets/scss/components/_menu-content.scss
+++ b/assets/scss/components/_menu-content.scss
@@ -32,9 +32,11 @@
   }
 }
 
-#TableOfContents {
-  ul li:not(:first-child) {
-    margin: 0.75rem 0;
-  }
+#TableOfContents li {
+    margin-top: 0.4rem;
+    margin-bottom: 0.4rem;
 }
 
+#TableOfContents li li {
+    margin-left: 1em;
+}


### PR DESCRIPTION
As discussed in #11.

The existing TOC code was additionally preventing multiple sub-headings to be indented, why I removed it. Please let me know of any concerns. 